### PR TITLE
Sync registration and credential update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,14 +53,25 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/org.keycloak/keycloak-server-spi-private -->
+<!--         https://mvnrepository.com/artifact/org.keycloak/keycloak-server-spi-private-->
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-server-spi-private</artifactId>
             <version>${keycloak.version}</version>
             <scope>provided</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-adapter-spi</artifactId>
+            <version>${keycloak.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-services</artifactId>
+            <version>${keycloak.version}</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-model-storage</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,13 @@
     </dependencyManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>10.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- https://mvnrepository.com/artifact/org.keycloak/keycloak-core -->
         <dependency>
             <groupId>org.keycloak</groupId>

--- a/src/main/java/com/danielfrak/code/keycloak/providers/authenticators/CustomIdpCreateUserIfUniqueAuthenticator.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/authenticators/CustomIdpCreateUserIfUniqueAuthenticator.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.danielfrak.code.keycloak.providers.authenticators;
 
 import jakarta.ws.rs.core.Response;
@@ -21,6 +38,9 @@ import org.keycloak.services.messages.Messages;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
 public class CustomIdpCreateUserIfUniqueAuthenticator extends AbstractIdpAuthenticator {
 
     private static Logger logger = Logger.getLogger(com.danielfrak.code.keycloak.providers.authenticators.CustomIdpCreateUserIfUniqueAuthenticator.class);

--- a/src/main/java/com/danielfrak/code/keycloak/providers/authenticators/CustomIdpCreateUserIfUniqueAuthenticator.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/authenticators/CustomIdpCreateUserIfUniqueAuthenticator.java
@@ -1,0 +1,153 @@
+package com.danielfrak.code.keycloak.providers.authenticators;
+
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.authenticators.broker.AbstractIdpAuthenticator;
+import org.keycloak.authentication.authenticators.broker.IdpCreateUserIfUniqueAuthenticatorFactory;
+import org.keycloak.authentication.authenticators.broker.util.ExistingUserInfo;
+import org.keycloak.authentication.authenticators.broker.util.SerializedBrokeredIdentityContext;
+import org.keycloak.broker.provider.BrokeredIdentityContext;
+import org.keycloak.events.Details;
+import org.keycloak.events.Errors;
+import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.light.LightweightUserAdapter;
+import org.keycloak.services.ServicesLogger;
+import org.keycloak.services.messages.Messages;
+
+import java.util.List;
+import java.util.Map;
+
+public class CustomIdpCreateUserIfUniqueAuthenticator extends AbstractIdpAuthenticator {
+
+    private static Logger logger = Logger.getLogger(com.danielfrak.code.keycloak.providers.authenticators.CustomIdpCreateUserIfUniqueAuthenticator.class);
+
+
+    @Override
+    protected void actionImpl(AuthenticationFlowContext context, SerializedBrokeredIdentityContext serializedCtx, BrokeredIdentityContext brokerContext) {
+    }
+
+    @Override
+    protected void authenticateImpl(AuthenticationFlowContext context, SerializedBrokeredIdentityContext serializedCtx, BrokeredIdentityContext brokerContext) {
+
+        KeycloakSession session = context.getSession();
+        RealmModel realm = context.getRealm();
+
+        if (context.getAuthenticationSession().getAuthNote(EXISTING_USER_INFO) != null) {
+            context.attempted();
+            return;
+        }
+
+        String username = getUsername(context, serializedCtx, brokerContext);
+        if (username == null) {
+            ServicesLogger.LOGGER.resetFlow(realm.isRegistrationEmailAsUsername() ? "Email" : "Username");
+            context.getAuthenticationSession().setAuthNote(ENFORCE_UPDATE_PROFILE, "true");
+            context.resetFlow();
+            return;
+        }
+
+        ExistingUserInfo duplication = brokerContext.getIdpConfig().isTransientUsers() ? null : checkExistingUser(context, username, serializedCtx, brokerContext);
+
+        UserModel federatedUser = null;
+        if (brokerContext.getIdpConfig().isTransientUsers()) {
+            logger.debugf("Transient brokering requested. Recording user details for account '%s' and from identity provider '%s' .",
+                    username, brokerContext.getIdpConfig().getAlias());
+
+            federatedUser = new LightweightUserAdapter(session, context.getAuthenticationSession().getParentSession().getId());
+            federatedUser.setUsername(username);
+        } else if (duplication == null) {
+            logger.debugf("No duplication detected. Creating account for user '%s' and linking with identity provider '%s' .",
+                    username, brokerContext.getIdpConfig().getAlias());
+
+            serializedCtx.saveToAuthenticationSession(context.getAuthenticationSession(), "broker_context");
+            federatedUser = session.users().addUser(realm, username);
+        }
+
+        if (federatedUser != null) {
+            federatedUser.setEnabled(true);
+
+            for (Map.Entry<String, List<String>> attr : serializedCtx.getAttributes().entrySet().stream().sorted(Map.Entry.comparingByKey()).toList()) {
+                if (!UserModel.USERNAME.equalsIgnoreCase(attr.getKey())) {
+                    federatedUser.setAttribute(attr.getKey(), attr.getValue());
+                }
+            }
+
+            AuthenticatorConfigModel config = context.getAuthenticatorConfig();
+            if (config != null && Boolean.parseBoolean(config.getConfig().get(IdpCreateUserIfUniqueAuthenticatorFactory.REQUIRE_PASSWORD_UPDATE_AFTER_REGISTRATION))) {
+                logger.debugf("User '%s' required to update password", federatedUser.getUsername());
+                federatedUser.addRequiredAction(UserModel.RequiredAction.UPDATE_PASSWORD);
+            }
+
+            userRegisteredSuccess(context, federatedUser, serializedCtx, brokerContext);
+
+            context.setUser(federatedUser);
+            context.getAuthenticationSession().setAuthNote(BROKER_REGISTERED_NEW_USER, "true");
+            context.success();
+        } else {
+            logger.debugf("Duplication detected. There is already existing user with %s '%s' .",
+                    duplication.getDuplicateAttributeName(), duplication.getDuplicateAttributeValue());
+
+            // Set duplicated user, so next authenticators can deal with it
+            context.getAuthenticationSession().setAuthNote(EXISTING_USER_INFO, duplication.serialize());
+            //Only show error message if the authenticator was required
+            if (context.getExecution().isRequired()) {
+                Response challengeResponse = context.form()
+                        .setError(Messages.FEDERATED_IDENTITY_EXISTS, duplication.getDuplicateAttributeName(), duplication.getDuplicateAttributeValue())
+                        .createErrorPage(Response.Status.CONFLICT);
+                context.challenge(challengeResponse);
+                context.getEvent()
+                        .user(duplication.getExistingUserId())
+                        .detail("existing_" + duplication.getDuplicateAttributeName(), duplication.getDuplicateAttributeValue())
+                        .removeDetail(Details.AUTH_METHOD)
+                        .removeDetail(Details.AUTH_TYPE)
+                        .error(Errors.FEDERATED_IDENTITY_EXISTS);
+            } else {
+                context.attempted();
+            }
+        }
+    }
+
+    // Could be overriden to detect duplication based on other criterias (firstName, lastName, ...)
+    protected ExistingUserInfo checkExistingUser(AuthenticationFlowContext context, String username, SerializedBrokeredIdentityContext serializedCtx, BrokeredIdentityContext brokerContext) {
+
+        if (brokerContext.getEmail() != null && !context.getRealm().isDuplicateEmailsAllowed()) {
+            UserModel existingUser = context.getSession().users().getUserByEmail(context.getRealm(), brokerContext.getEmail());
+            if (existingUser != null) {
+                return new ExistingUserInfo(existingUser.getId(), UserModel.EMAIL, existingUser.getEmail());
+            }
+        }
+
+        UserModel existingUser = context.getSession().users().getUserByUsername(context.getRealm(), username);
+        if (existingUser != null) {
+            return new ExistingUserInfo(existingUser.getId(), UserModel.USERNAME, existingUser.getUsername());
+        }
+
+        return null;
+    }
+
+    protected String getUsername(AuthenticationFlowContext context, SerializedBrokeredIdentityContext serializedCtx, BrokeredIdentityContext brokerContext) {
+        RealmModel realm = context.getRealm();
+        return realm.isRegistrationEmailAsUsername() ? brokerContext.getEmail() : brokerContext.getModelUsername();
+    }
+
+
+    // Empty method by default. This exists, so subclass can override and add callback after new user is registered through social
+    protected void userRegisteredSuccess(AuthenticationFlowContext context, UserModel registeredUser, SerializedBrokeredIdentityContext serializedCtx, BrokeredIdentityContext brokerContext) {
+
+    }
+
+
+    @Override
+    public boolean requiresUser() {
+        return false;
+    }
+
+    @Override
+    public boolean configuredFor(KeycloakSession session, RealmModel realm, UserModel user) {
+        return true;
+    }
+
+}

--- a/src/main/java/com/danielfrak/code/keycloak/providers/authenticators/CustomIdpCreateUserIfUniqueAuthenticatorFactory.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/authenticators/CustomIdpCreateUserIfUniqueAuthenticatorFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.danielfrak.code.keycloak.providers.authenticators;
 
 import org.keycloak.Config;
@@ -11,6 +28,9 @@ import org.keycloak.provider.ProviderConfigProperty;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
 public class CustomIdpCreateUserIfUniqueAuthenticatorFactory implements AuthenticatorFactory {
 
     public static final String PROVIDER_ID = "custom-idp-create-user-if-unique";

--- a/src/main/java/com/danielfrak/code/keycloak/providers/authenticators/CustomIdpCreateUserIfUniqueAuthenticatorFactory.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/authenticators/CustomIdpCreateUserIfUniqueAuthenticatorFactory.java
@@ -1,0 +1,94 @@
+package com.danielfrak.code.keycloak.providers.authenticators;
+
+import org.keycloak.Config;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.AuthenticatorFactory;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CustomIdpCreateUserIfUniqueAuthenticatorFactory implements AuthenticatorFactory {
+
+    public static final String PROVIDER_ID = "custom-idp-create-user-if-unique";
+    static CustomIdpCreateUserIfUniqueAuthenticator SINGLETON = new CustomIdpCreateUserIfUniqueAuthenticator();
+
+    public static final String REQUIRE_PASSWORD_UPDATE_AFTER_REGISTRATION = "require.password.update.after.registration";
+
+    @Override
+    public Authenticator create(KeycloakSession session) {
+        return SINGLETON;
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getReferenceCategory() {
+        return "createUserIfUnique";
+    }
+
+    @Override
+    public boolean isConfigurable() {
+        return true;
+    }
+
+    @Override
+    public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
+        return REQUIREMENT_CHOICES;
+    }
+
+    @Override
+    public String getDisplayType() {
+        return "Custom Create User If Unique";
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Detect if there is existing Keycloak account with same email like identity provider. If no, create new user";
+    }
+
+    @Override
+    public boolean isUserSetupAllowed() {
+        return false;
+    }
+
+    private static final List<ProviderConfigProperty> configProperties = new ArrayList<>();
+
+    static {
+        ProviderConfigProperty property;
+        property = new ProviderConfigProperty();
+        property.setName(REQUIRE_PASSWORD_UPDATE_AFTER_REGISTRATION);
+        property.setLabel("Require Password Update After Registration");
+        property.setType(ProviderConfigProperty.BOOLEAN_TYPE);
+        property.setHelpText("If this option is true and new user is successfully imported from Identity Provider to Keycloak (there is no duplicated email or username detected in Keycloak DB), then this user is required to update his password");
+        configProperties.add(property);
+    }
+
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return configProperties;
+    }
+}
+

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/LegacyProvider.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/LegacyProvider.java
@@ -186,6 +186,7 @@ public class LegacyProvider implements UserStorageProvider,
             }
         } catch (RestUserProviderException e) {
             LOG.errorf("Failed to remove user: %s", user.getUsername(), e);
+            return false;
         }
 
         severFederationLink(user);

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/LegacyProvider.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/LegacyProvider.java
@@ -4,7 +4,9 @@ import com.danielfrak.code.keycloak.providers.rest.exceptions.RestUserProviderEx
 import com.danielfrak.code.keycloak.providers.rest.remote.LegacyUser;
 import com.danielfrak.code.keycloak.providers.rest.remote.LegacyUserService;
 import com.danielfrak.code.keycloak.providers.rest.remote.UserModelFactory;
+
 import org.jboss.logging.Logger;
+import org.keycloak.authentication.authenticators.broker.util.SerializedBrokeredIdentityContext;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.credential.CredentialInput;
 import org.keycloak.credential.CredentialInputUpdater;
@@ -15,13 +17,12 @@ import org.keycloak.models.UserModel;
 import org.keycloak.models.credential.PasswordCredentialModel;
 import org.keycloak.policy.PasswordPolicyManagerProvider;
 import org.keycloak.policy.PolicyError;
+import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.storage.UserStorageProvider;
 import org.keycloak.storage.user.UserLookupProvider;
 import org.keycloak.storage.user.UserRegistrationProvider;
 
-import java.util.Collections;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -48,7 +49,6 @@ public class LegacyProvider implements UserStorageProvider,
         this.userModelFactory = userModelFactory;
         this.model = model;
     }
-
 
     private UserModel getUserModel(RealmModel realm, String username, Supplier<Optional<LegacyUser>> user) {
         return user.get()
@@ -156,12 +156,31 @@ public class LegacyProvider implements UserStorageProvider,
 
     @Override
     public UserModel addUser(RealmModel realm, String username) {
-        String password = getFormParameter("password");
-        String firstName = getFormParameter("firstName");
-        String lastName = getFormParameter("lastName");
+        String password = null, firstName = null, lastName = null, picture = null, broker_id = null;
+
+        // if the user was created by a broker (e.g. Facebook), retrieve the broker context
+        AuthenticationSessionModel authSession = this.session.getContext().getAuthenticationSession();
+        if (authSession.getAuthNote("broker_context") != null) {
+            try {
+                SerializedBrokeredIdentityContext brokerContext =
+                        SerializedBrokeredIdentityContext.readFromAuthenticationSession(authSession, "broker_context");
+
+                firstName = brokerContext.getFirstName();
+                lastName = brokerContext.getLastName();
+                picture = brokerContext.getAttribute("picture").getFirst();
+                broker_id = brokerContext.getAttribute("broker_id").getFirst();
+            } catch (Exception e) {
+                LOG.error("Error deserializing broker context", e);
+            }
+        // otherwise, get the user details from the registration form
+        } else {
+            firstName = getFormParameter("firstName");
+            lastName = getFormParameter("lastName");
+            password = getFormParameter("password");
+        }
 
         try {
-            var user = legacyUserService.addUser(username, password, firstName, lastName);
+            var user = legacyUserService.addUser(username, password, firstName, lastName, picture, broker_id);
             return user.map(legacyUser -> userModelFactory.create(legacyUser, realm)).orElse(null);
         } catch (RestUserProviderException e) {
             LOG.errorf("Failed to add user: %s", username, e);

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/remote/LegacyUserService.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/remote/LegacyUserService.java
@@ -35,4 +35,6 @@ public interface LegacyUserService {
     boolean updateCredential(String username, String password);
 
     Optional<LegacyUser> addUser(String email, String password, String firstName, String lastName);
+
+    boolean removeUser(String username);
 }

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/remote/LegacyUserService.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/remote/LegacyUserService.java
@@ -31,4 +31,8 @@ public interface LegacyUserService {
      * @return true if password is valid.
      */
     boolean isPasswordValid(String username, String password);
+
+    boolean updateCredential(String username, String password);
+
+    Optional<LegacyUser> addUser(String email, String password, String firstName, String lastName);
 }

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/remote/LegacyUserService.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/remote/LegacyUserService.java
@@ -34,7 +34,7 @@ public interface LegacyUserService {
 
     boolean updateCredential(String username, String password);
 
-    Optional<LegacyUser> addUser(String email, String password, String firstName, String lastName);
+    Optional<LegacyUser> addUser(String email, String password, String firstName, String lastName, String picture, String broker_id);
 
     boolean removeUser(String username);
 }

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/rest/RestUserService.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/rest/RestUserService.java
@@ -120,12 +120,21 @@ public class RestUserService implements LegacyUserService {
     }
 
     @Override
-    public Optional<LegacyUser> addUser(String email, String password, String firstName, String lastName) {
+    public Optional<LegacyUser> addUser(String email, String password, String firstName, String lastName, String picture, String broker_id) {
         var userJson = objectMapper.createObjectNode();
         userJson.put("email", email);
-        userJson.put("password", password);
         userJson.put("firstName", firstName);
         userJson.put("lastName", lastName);
+
+        if (password != null) {
+            userJson.put("password", password);
+        }
+        if (picture != null) {
+            userJson.put("picture", picture);
+        }
+        if (broker_id != null) {
+            userJson.put("brokerId", broker_id);
+        }
 
         try {
             var json = objectMapper.writeValueAsString(userJson);

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/rest/RestUserService.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/rest/RestUserService.java
@@ -139,4 +139,18 @@ public class RestUserService implements LegacyUserService {
             throw new RestUserProviderException(e);
         }
     }
+
+    @Override
+    public boolean removeUser(String username) {
+        if (username != null) {
+            username = Encode.urlEncode(username);
+        }
+        var removeUserUri = String.format("%s/%s", this.uri, username);
+        try {
+            var response = httpClient.delete(removeUserUri);
+            return response.getCode() == HttpStatus.SC_OK;
+        } catch (RuntimeException e) {
+            throw new RestUserProviderException(e);
+        }
+    }
 }

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/rest/RestUserService.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/rest/RestUserService.java
@@ -119,8 +119,6 @@ public class RestUserService implements LegacyUserService {
 
     @Override
     public Optional<LegacyUser> addUser(String email, String password, String firstName, String lastName) {
-        var addUserUri = String.format("%s/%s", uri, "add_user");
-
         var userJson = objectMapper.createObjectNode();
         userJson.put("email", email);
         userJson.put("password", password);
@@ -129,7 +127,7 @@ public class RestUserService implements LegacyUserService {
 
         try {
             var json = objectMapper.writeValueAsString(userJson);
-            var response = httpClient.post(addUserUri, json);
+            var response = httpClient.put(uri, json);
             if (response.getCode() != HttpStatus.SC_OK) {
                 return Optional.empty();
             }

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/rest/RestUserService.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/rest/RestUserService.java
@@ -17,6 +17,8 @@ import static com.danielfrak.code.keycloak.providers.rest.ConfigurationPropertie
 
 public class RestUserService implements LegacyUserService {
 
+    private static final String RECORD_NOT_FOUND_RESP = "record_not_found";
+
     private final String uri;
     private final HttpClient httpClient;
     private final ObjectMapper objectMapper;
@@ -146,10 +148,10 @@ public class RestUserService implements LegacyUserService {
         var removeUserUri = String.format("%s/%s", this.uri, username);
         try {
             var response = httpClient.delete(removeUserUri);
-            if (response.getCode() == HttpStatus.SC_NOT_FOUND) {
+            if (response.getCode() == HttpStatus.SC_NOT_FOUND && response.getBody().contains(RECORD_NOT_FOUND_RESP)) {
                 return true;
             }
-            
+
             return response.getCode() == HttpStatus.SC_OK;
         } catch (RuntimeException e) {
             throw new RestUserProviderException(e);

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/rest/RestUserService.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/rest/RestUserService.java
@@ -146,6 +146,10 @@ public class RestUserService implements LegacyUserService {
         var removeUserUri = String.format("%s/%s", this.uri, username);
         try {
             var response = httpClient.delete(removeUserUri);
+            if (response.getCode() == HttpStatus.SC_NOT_FOUND) {
+                return true;
+            }
+            
             return response.getCode() == HttpStatus.SC_OK;
         } catch (RuntimeException e) {
             throw new RestUserProviderException(e);

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/rest/http/HttpClient.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/rest/http/HttpClient.java
@@ -3,7 +3,6 @@ package com.danielfrak.code.keycloak.providers.rest.rest.http;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
-import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.*;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
@@ -69,11 +68,8 @@ public class HttpClient {
 
     private HttpResponse getHttpResponse(CloseableHttpResponse response) throws IOException {
         int statusCode = response.getStatusLine().getStatusCode();
-        if (statusCode != HttpStatus.SC_OK) {
-            return new HttpResponse(statusCode);
-        }
-
         String entityAsString = getEntityAsString(response);
+
         return new HttpResponse(statusCode, entityAsString);
     }
 

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/rest/http/HttpClient.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/rest/http/HttpClient.java
@@ -96,6 +96,13 @@ public class HttpClient {
         return execute(request);
     }
 
+    public HttpResponse put(String uri, String bodyAsJson) {
+        var request = new HttpPut(uri);
+        var requestEntity = new StringEntity(bodyAsJson, ContentType.APPLICATION_JSON);
+        request.setEntity(requestEntity);
+        return execute(request);
+    }
+
     public HttpResponse patch(String uri, String bodyAsJson) {
         var request = new HttpPatch(uri);
         var requestEntity = new StringEntity(bodyAsJson, ContentType.APPLICATION_JSON);

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/rest/http/HttpClient.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/rest/http/HttpClient.java
@@ -102,4 +102,9 @@ public class HttpClient {
         request.setEntity(requestEntity);
         return execute(request);
     }
+
+    public HttpResponse delete(String uri) {
+        var request = new HttpDelete(uri);
+        return execute(request);
+    }
 }

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/rest/http/HttpClient.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/rest/http/HttpClient.java
@@ -4,10 +4,7 @@ import org.apache.commons.codec.binary.Base64;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.*;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -94,6 +91,13 @@ public class HttpClient {
 
     public HttpResponse post(String uri, String bodyAsJson) {
         var request = new HttpPost(uri);
+        var requestEntity = new StringEntity(bodyAsJson, ContentType.APPLICATION_JSON);
+        request.setEntity(requestEntity);
+        return execute(request);
+    }
+
+    public HttpResponse patch(String uri, String bodyAsJson) {
+        var request = new HttpPatch(uri);
         var requestEntity = new StringEntity(bodyAsJson, ContentType.APPLICATION_JSON);
         request.setEntity(requestEntity);
         return execute(request);

--- a/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
+++ b/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
@@ -1,0 +1,1 @@
+com.danielfrak.code.keycloak.providers.authenticators.CustomIdpCreateUserIfUniqueAuthenticatorFactory

--- a/src/test/java/com/danielfrak/code/keycloak/providers/rest/LegacyProviderTest.java
+++ b/src/test/java/com/danielfrak/code/keycloak/providers/rest/LegacyProviderTest.java
@@ -303,42 +303,6 @@ class LegacyProviderTest {
     }
 
     @Test
-    void shouldRemoveFederationLinkWhenCredentialUpdates() {
-        var input = mock(CredentialInput.class);
-        when(userModel.getFederationLink())
-                .thenReturn("someId");
-
-        assertFalse(legacyProvider.updateCredential(realmModel, userModel, input));
-
-        verify(userModel)
-                .setFederationLink(null);
-    }
-
-    @Test
-    void shouldNotRemoveFederationLinkWhenBlankAndCredentialUpdates() {
-        var input = mock(CredentialInput.class);
-        when(userModel.getFederationLink())
-                .thenReturn(" ");
-
-        assertFalse(legacyProvider.updateCredential(realmModel, userModel, input));
-
-        verify(userModel, never())
-                .setFederationLink(null);
-    }
-
-    @Test
-    void shouldNotRemoveFederationLinkWhenNullAndCredentialUpdates() {
-        var input = mock(CredentialInput.class);
-        when(userModel.getFederationLink())
-                .thenReturn(null);
-
-        assertFalse(legacyProvider.updateCredential(realmModel, userModel, input));
-
-        verify(userModel, never())
-                .setFederationLink(null);
-    }
-
-    @Test
     void disableCredentialTypeShouldDoNothing() {
         legacyProvider.disableCredentialType(realmModel, userModel, "someType");
         Mockito.verifyNoInteractions(session, legacyUserService, userModelFactory, realmModel, userModel);

--- a/src/test/java/com/danielfrak/code/keycloak/providers/rest/rest/http/HttpClientTest.java
+++ b/src/test/java/com/danielfrak/code/keycloak/providers/rest/rest/http/HttpClientTest.java
@@ -9,10 +9,8 @@ import okio.Buffer;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
-import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.LaxRedirectStrategy;
@@ -31,7 +29,6 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.*;
 
 class HttpClientTest {
@@ -81,11 +78,10 @@ class HttpClientTest {
     void getShouldReturnResponseWhenHttpCodeNot200() throws InterruptedException {
         enqueueFailedResponse();
 
-        HttpResponse response = httpClient.get(uri);
+        httpClient.get(uri);
 
         RecordedRequest recordedRequest = Objects.requireNonNull(
                 mockWebServer.takeRequest(5, TimeUnit.SECONDS));
-        assertNull(response.body);
         assertEquals(HttpGet.METHOD_NAME, recordedRequest.getMethod());
         assertEquals("/", recordedRequest.getPath());
         assertEquals(uri, Objects.requireNonNull(recordedRequest.getRequestUrl()).toString());
@@ -337,11 +333,10 @@ class HttpClientTest {
     void postShouldReturnResponseWhenHttpCodeNot200() throws InterruptedException {
         enqueueFailedResponse();
 
-        HttpResponse response = httpClient.post(uri, "{}");
+        httpClient.post(uri, "{}");
 
         RecordedRequest recordedRequest = Objects.requireNonNull(
                 mockWebServer.takeRequest(5, TimeUnit.SECONDS));
-        assertNull(response.body);
         assertEquals(HttpPost.METHOD_NAME, recordedRequest.getMethod());
         assertEquals("/", recordedRequest.getPath());
         assertEquals(uri, Objects.requireNonNull(recordedRequest.getRequestUrl()).toString());


### PR DESCRIPTION
- Implement `CredentialInputValidator` interface
- Implement `UserRegistrationProvider` interface
- Do not severe federated user link after the first sync
- Override `IdpCreateUserIfUniqueAuthenticator` to provide broker context