### PR TITLE
Pass provider name (ex. 'facebook') to the federated storage when creating users

### DIFF
--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/LegacyProvider.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/LegacyProvider.java
@@ -156,7 +156,7 @@ public class LegacyProvider implements UserStorageProvider,
 
     @Override
     public UserModel addUser(RealmModel realm, String username) {
-        String password = null, firstName = null, lastName = null, picture = null, provider_id = null;
+        String password = null, firstName = null, lastName = null, picture = null, provider = null, providerUserId = null;
 
         // if the user was created by a broker (e.g. Facebook), retrieve the broker context
         AuthenticationSessionModel authSession = this.session.getContext().getAuthenticationSession();
@@ -168,7 +168,8 @@ public class LegacyProvider implements UserStorageProvider,
                 firstName = brokerContext.getFirstName();
                 lastName = brokerContext.getLastName();
                 picture = brokerContext.getAttribute("picture").getFirst();
-                provider_id = brokerContext.getAttribute("provider_id").getFirst();
+                provider = brokerContext.getIdentityProviderId();
+                providerUserId = brokerContext.getId();
             } catch (Exception e) {
                 LOG.error("Error deserializing broker context", e);
             }
@@ -180,7 +181,7 @@ public class LegacyProvider implements UserStorageProvider,
         }
 
         try {
-            var user = legacyUserService.addUser(username, password, firstName, lastName, picture, provider_id);
+            var user = legacyUserService.addUser(username, password, firstName, lastName, picture, provider, providerUserId);
             return user.map(legacyUser -> userModelFactory.create(legacyUser, realm)).orElse(null);
         } catch (RestUserProviderException e) {
             LOG.errorf("Failed to add user: %s", username, e);

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/remote/LegacyUserService.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/remote/LegacyUserService.java
@@ -34,7 +34,7 @@ public interface LegacyUserService {
 
     boolean updateCredential(String username, String password);
 
-    Optional<LegacyUser> addUser(String email, String password, String firstName, String lastName, String picture, String provider_id);
+    Optional<LegacyUser> addUser(String email, String password, String firstName, String lastName, String picture, String provider, String providerUserId);
 
     boolean removeUser(String username);
 }

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/rest/RestUserService.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/rest/RestUserService.java
@@ -120,21 +120,15 @@ public class RestUserService implements LegacyUserService {
     }
 
     @Override
-    public Optional<LegacyUser> addUser(String email, String password, String firstName, String lastName, String picture, String provider_id) {
+    public Optional<LegacyUser> addUser(String email, String password, String firstName, String lastName, String picture, String provider, String providerUserId) {
         var userJson = objectMapper.createObjectNode();
         userJson.put("email", email);
         userJson.put("firstName", firstName);
         userJson.put("lastName", lastName);
-
-        if (password != null) {
-            userJson.put("password", password);
-        }
-        if (picture != null) {
-            userJson.put("picture", picture);
-        }
-        if (provider_id != null) {
-            userJson.put("providerId", provider_id);
-        }
+        userJson.put("password", password);
+        userJson.put("picture", picture);
+        userJson.put("provider", provider);
+        userJson.put("providerUserId", providerUserId);
 
         try {
             var json = objectMapper.writeValueAsString(userJson);


### PR DESCRIPTION
- Added a `provider` parameter to support sync of multiple providers like Apple or Google.
- `providerId` got renamed to `providerUserId`.